### PR TITLE
feat: generalize image prompt

### DIFF
--- a/sui/packages/atoma/sources/db.move
+++ b/sui/packages/atoma/sources/db.move
@@ -591,7 +591,7 @@ module atoma::db {
             balance::zero()
         } else {
             let p = self.permille_to_slash_node_on_timeout;
-            let amount_to_slash = sui::math::divide_and_round_up(
+            let amount_to_slash = std::u64::divide_and_round_up(
                    collateral * p,
             // -------------------
                        1000

--- a/sui/packages/atoma/sources/gate.move
+++ b/sui/packages/atoma/sources/gate.move
@@ -2,7 +2,6 @@ module atoma::gate {
     use atoma::db::{SmallId, ModelEchelon, AtomaDb};
     use atoma::settlement::SettlementTicket;
     use std::ascii;
-    use std::string;
     use sui::balance::Balance;
     use sui::dynamic_field;
     use toma::toma::TOMA;
@@ -85,7 +84,7 @@ module atoma::gate {
         /// Represents a floating point number, little endian.
         guidance_scale: u32,
         height: u64,
-        img2img: Option<string::String>,
+        img2img: Option<vector<u8>>,
         /// Represents a floating point number, little endian
         img2img_strength: u32,
         model: ascii::String,
@@ -94,9 +93,9 @@ module atoma::gate {
         /// The user pays for each image.
         num_samples: u64,
         output_destination: vector<u8>,
-        prompt: string::String,
+        prompt: vector<u8>,
         random_seed: u64,
-        uncond_prompt: string::String,
+        uncond_prompt: vector<u8>,
         width: u64,
     }
 
@@ -286,14 +285,14 @@ module atoma::gate {
         guidance_scale: u32,
         height: u64,
         img2img_strength: u32,
-        img2img: Option<string::String>,
+        img2img: Option<vector<u8>>,
         model: ascii::String,
         n_steps: u64,
         num_samples: u64,
         output_destination: vector<u8>,
-        prompt: string::String,
+        prompt: vector<u8>,
         random_seed: u64,
-        uncond_prompt: string::String,
+        uncond_prompt: vector<u8>,
         width: u64,
     ): Text2ImagePromptParams {
         Text2ImagePromptParams {

--- a/sui/packages/atoma/sources/prompts.move
+++ b/sui/packages/atoma/sources/prompts.move
@@ -17,7 +17,6 @@ module atoma::prompts {
 
     use atoma::db::AtomaDb;
     use std::ascii;
-    use std::string;
     use sui::coin::Coin;
     use sui::random::Random;
     use toma::toma::TOMA;
@@ -75,13 +74,15 @@ module atoma::prompts {
 
     /// Submits a text prompt to Atoma network that asks for an image of
     /// a pixel art Colosseum.
-    entry fun generate_nft(
+    entry fun send_image_prompt(
         atoma: &mut AtomaDb,
         wallet: &mut Coin<TOMA>,
         model: ascii::String,
         output_destination: vector<u8>,
         max_fee_per_input_token: u64,
         max_fee_per_output_pixel: u64,
+        prompt: vector<u8>,
+        uncond_prompt: vector<u8>,
         random: &Random,
         ctx: &mut TxContext,
     ) {
@@ -91,8 +92,6 @@ module atoma::prompts {
         let height = 256;
         let n_steps = 40;
         let num_samples = 2;
-        let prompt = string::utf8(b"Generate a bored ape NFT");
-        let uncond_prompt = string::utf8(b"Shinny, bright, bored, blue background");
         let random_seed = rng.generate_u64();
         let width = 256;
         let img2img_strength = 1065353216; // 1.0

--- a/sui/packages/atoma/sources/settlement.move
+++ b/sui/packages/atoma/sources/settlement.move
@@ -601,7 +601,7 @@ module atoma::settlement {
             };
         };
 
-        let oracle_reward = sui::math::divide_and_round_up(
+        let oracle_reward = std::u64::divide_and_round_up(
             confiscated_total.value() * atoma.get_permille_for_oracle_on_dispute(),
         // ----------------------------------------------------------------------
                                 1000


### PR DESCRIPTION
Generalize image prompt to send input source, instead of pure text.
Fix the deprecation warnings.